### PR TITLE
Rename repo references from android-cli to unified-android-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # acli — Unified Android CLI
 
-[![CI](https://github.com/ErikHellman/android-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/ErikHellman/android-cli/actions/workflows/ci.yml)
+[![CI](https://github.com/ErikHellman/unified-android-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/ErikHellman/unified-android-cli/actions/workflows/ci.yml)
 
 A single, ergonomic command-line interface for all Android development tasks. `acli` wraps `sdkmanager`, `avdmanager`, `adb`, `fastboot`, and Gradle so you never have to memorize package paths, flag syntax, or which binary lives where.
 
@@ -28,13 +28,13 @@ $ acli doctor
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ErikHellman/android-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ErikHellman/unified-android-cli/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/ErikHellman/android-cli/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/ErikHellman/unified-android-cli/main/install.ps1 | iex
 ```
 
 **Windows via WSL:** Run the macOS/Linux command above inside your WSL terminal.
@@ -395,7 +395,7 @@ default_device: "emulator-5554"
 sdk_root: ""
 
 # GitHub repository used for self-update checks.
-github_repo: "ErikHellman/android-cli"
+github_repo: "ErikHellman/unified-android-cli"
 ```
 
 ### SDK Auto-Discovery
@@ -512,15 +512,15 @@ Beyond the quick-start one-liner, here are all the ways to install `acli`.
 ### Build from source
 
 ```bash
-git clone https://github.com/ErikHellman/android-cli.git
-cd android-cli
+git clone https://github.com/ErikHellman/unified-unified-android-cli.git
+cd unified-android-cli
 make install          # builds and installs to $GOPATH/bin
 ```
 
 Or without `make`:
 
 ```bash
-go install github.com/ErikHellman/android-cli/cmd/acli@latest
+go install github.com/ErikHellman/unified-android-cli/cmd/acli@latest
 ```
 
 ### Build dependencies
@@ -582,8 +582,8 @@ The error catalog covers: device not found, multiple devices, unauthorized devic
 ### Getting started
 
 ```bash
-git clone https://github.com/ErikHellman/android-cli.git
-cd android-cli
+git clone https://github.com/ErikHellman/unified-unified-android-cli.git
+cd unified-android-cli
 
 go mod download        # download dependencies
 make build             # build dist/acli
@@ -694,7 +694,7 @@ This is the trigger. Pushing the tag starts the release workflow automatically �
 
 **Verifying the release**
 
-After the workflow completes (~2 minutes), check the [Releases page](https://github.com/ErikHellman/android-cli/releases) and confirm:
+After the workflow completes (~2 minutes), check the [Releases page](https://github.com/ErikHellman/unified-android-cli/releases) and confirm:
 - All 5 binaries are present
 - `checksums.txt` and `.sha256` sidecars are attached
 - `acli update check` reports the new version
@@ -704,7 +704,7 @@ After the workflow completes (~2 minutes), check the [Releases page](https://git
 ## Project Structure
 
 ```
-android-cli/
+unified-android-cli/
 ├── cmd/
 │   └── acli/
 │       └── main.go              # Entry point; injects version/commit

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Beyond the quick-start one-liner, here are all the ways to install `acli`.
 ### Build from source
 
 ```bash
-git clone https://github.com/ErikHellman/unified-unified-android-cli.git
+git clone https://github.com/ErikHellman/unified-android-cli.git
 cd unified-android-cli
 make install          # builds and installs to $GOPATH/bin
 ```
@@ -582,7 +582,7 @@ The error catalog covers: device not found, multiple devices, unauthorized devic
 ### Getting started
 
 ```bash
-git clone https://github.com/ErikHellman/unified-unified-android-cli.git
+git clone https://github.com/ErikHellman/unified-android-cli.git
 cd unified-android-cli
 
 go mod download        # download dependencies

--- a/cmd/acli/main.go
+++ b/cmd/acli/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/ErikHellman/android-cli/internal/cmd"
+	"github.com/ErikHellman/unified-android-cli/internal/cmd"
 )
 
 // version and commit are injected by the Makefile via -ldflags.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ErikHellman/android-cli
+module github.com/ErikHellman/unified-android-cli
 
 go 1.26.1
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 $ErrorActionPreference = "Stop"
 
-$Repo    = "ErikHellman/android-cli"
+$Repo    = "ErikHellman/unified-android-cli"
 $Binary  = "acli"
 $Asset   = "${Binary}-windows-amd64.exe"
 $Url     = "https://github.com/${Repo}/releases/latest/download/${Asset}"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="ErikHellman/android-cli"
+REPO="ErikHellman/unified-android-cli"
 BINARY="acli"
 
 # Detect OS and architecture

--- a/internal/avd/service.go
+++ b/internal/avd/service.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // AVD represents a single Android Virtual Device.

--- a/internal/build/service.go
+++ b/internal/build/service.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // Service wraps Gradle wrapper operations.

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/avd.go
+++ b/internal/cmd/avd.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/internal/avd"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/avd"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/ErikHellman/android-cli/internal/build"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/build"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/device.go
+++ b/internal/cmd/device.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/ErikHellman/android-cli/internal/device"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/device"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -7,9 +7,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/flash.go
+++ b/internal/cmd/flash.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/internal/flash"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/flash"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/instrument.go
+++ b/internal/cmd/instrument.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/ErikHellman/android-cli/internal/instrument"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/instrument"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -4,8 +4,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/internal/project"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/project"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,9 +4,9 @@ package cmd
 import (
 	"os"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/config"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/config"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/ErikHellman/android-cli/internal/sdk"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/internal/sdk"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/ErikHellman/android-cli/pkg/config"
-	"github.com/ErikHellman/android-cli/pkg/output"
-	"github.com/ErikHellman/android-cli/pkg/update"
+	"github.com/ErikHellman/unified-android-cli/pkg/config"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/pkg/update"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/device/service.go
+++ b/internal/device/service.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // Device represents a connected ADB device or emulator.

--- a/internal/flash/service.go
+++ b/internal/flash/service.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // Device is a fastboot-mode device.

--- a/internal/instrument/service.go
+++ b/internal/instrument/service.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // Service wraps adb shell instrumentation commands.

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -10,8 +10,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // Service provides project scaffolding operations.

--- a/internal/sdk/bootstrap.go
+++ b/internal/sdk/bootstrap.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
 )
 
 const (

--- a/internal/sdk/service.go
+++ b/internal/sdk/service.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/android"
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/android"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 // Package represents an SDK package entry from sdkmanager --list.

--- a/pkg/aclerr/errors_test.go
+++ b/pkg/aclerr/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
 )
 
 func TestAcliError_Error(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,7 @@ func Load() error {
 	v.AutomaticEnv()
 
 	// Defaults
-	v.SetDefault("github_repo", "ErikHellman/android-cli")
+	v.SetDefault("github_repo", "ErikHellman/unified-android-cli")
 
 	cfgDir, err := configDir()
 	if err != nil {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
 	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
 )

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ErikHellman/android-cli/pkg/aclerr"
-	"github.com/ErikHellman/android-cli/pkg/output"
+	"github.com/ErikHellman/unified-android-cli/pkg/aclerr"
+	"github.com/ErikHellman/unified-android-cli/pkg/output"
 )
 
 // captureStderr temporarily replaces os.Stderr and returns captured content.

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ErikHellman/android-cli/pkg/runner"
+	"github.com/ErikHellman/unified-android-cli/pkg/runner"
 )
 
 func TestRunCapture_Echo(t *testing.T) {

--- a/pkg/update/updater.go
+++ b/pkg/update/updater.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const defaultRepo = "android-cli/acli"
+const defaultRepo = "ErikHellman/unified-android-cli"
 
 // Release represents a GitHub release.
 type Release struct {


### PR DESCRIPTION
## Summary

- Updates the Go module path from `github.com/ErikHellman/android-cli` to `github.com/ErikHellman/unified-android-cli` across all 28 Go source files and `go.mod`
- Updates `install.sh` and `install.ps1` to point to the new repo name
- Updates all GitHub URLs, clone examples, and the project structure tree in `README.md`
- Updates the `github_repo` default in `pkg/config/config.go`
- Fixes the malformed `defaultRepo` constant in `pkg/update/updater.go` (was `"android-cli/acli"`, now `"ErikHellman/unified-android-cli"`)

## Test plan

- [ ] `make build` compiles without errors (confirms all import paths resolve)
- [ ] `make test` passes
- [ ] `grep -r "ErikHellman/android-cli" . --include="*.go" --include="*.md" --include="*.sh" --include="*.ps1" go.mod` returns no results

https://claude.ai/code/session_01SGMpodd4CgnXrDtQKrieHr